### PR TITLE
Rename ethif to ethernet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - TESTS=true
     - PACKAGE="ethernet"
+    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
   matrix:
     - OCAML_VERSION=4.04
     - OCAML_VERSION=4.05

--- a/ethernet.opam
+++ b/ethernet.opam
@@ -22,8 +22,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.0.2"}
-  "mirage-net-lwt" {>= "1.0.0"}
-  "mirage-protocols-lwt" {>= "1.4.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
   "macaddr"
   "mirage-profile" {>= "0.5"}
   "fmt"

--- a/src/ethernet.ml
+++ b/src/ethernet.ml
@@ -26,9 +26,9 @@ module Make(Netif : Mirage_net_lwt.S) = struct
   type buffer = Cstruct.t
   type macaddr = Macaddr.t
 
-  type error = [ Mirage_protocols.Ethif.error | `Netif of Netif.error ]
+  type error = [ Mirage_protocols.Ethernet.error | `Netif of Netif.error ]
   let pp_error ppf = function
-    | #Mirage_protocols.Ethif.error as e -> Mirage_protocols.Ethif.pp_error ppf e
+    | #Mirage_protocols.Ethernet.error as e -> Mirage_protocols.Ethernet.pp_error ppf e
     | `Netif e -> Netif.pp_error ppf e
 
   type t = {

--- a/src/ethernet.ml
+++ b/src/ethernet.ml
@@ -20,8 +20,6 @@ open Lwt.Infix
 let src = Logs.Src.create "ethernet" ~doc:"Mirage Ethernet"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let default_mtu = 1500
-
 module Make(Netif : Mirage_net_lwt.S) = struct
 
   type 'a io = 'a Lwt.t
@@ -33,11 +31,10 @@ module Make(Netif : Mirage_net_lwt.S) = struct
 
   type t = {
     netif: Netif.t;
-    mtu: int;
   }
 
   let mac t = Netif.mac t.netif
-  let mtu t = t.mtu
+  let mtu t = Netif.mtu t.netif (* interface MTU excludes Ethernet header *)
 
   let input ~arpv4 ~ipv4 ~ipv6 t frame =
     let open Ethernet_packet in
@@ -48,36 +45,40 @@ module Make(Netif : Mirage_net_lwt.S) = struct
     match Unmarshal.of_cstruct frame with
     | Ok (header, payload) when of_interest header.destination ->
       begin
-        let open Ethernet_wire in
-        match header.ethertype with
-        | ARP -> arpv4 payload
-        | IPv4 -> ipv4 payload
-        | IPv6 -> ipv6 payload
+        match header.Ethernet_packet.ethertype with
+        | `ARP -> arpv4 payload
+        | `IPv4 -> ipv4 payload
+        | `IPv6 -> ipv6 payload
       end
     | Ok _ -> Lwt.return_unit
     | Error s ->
-      Log.debug (fun f -> f "Dropping Ethernet frame: %s" s);
+      Log.debug (fun f -> f "dropping Ethernet frame: %s" s);
       Lwt.return_unit
 
-  let write t frame =
+  let write t ?src destination ethertype ?size payload =
     MProf.Trace.label "ethernet.write";
-    Netif.write t.netif frame >|= function
+    let source = match src with None -> mac t | Some x -> x in
+    let fill frame =
+      match
+        Ethernet_packet.Marshal.into_cstruct
+          { source ; destination ; ethertype }
+          frame
+      with
+      | Error msg ->
+        Log.err (fun m -> m "error %s while marshalling ethernet header into allocated buffer" msg);
+        0
+      | Ok () ->
+        payload (Cstruct.shift frame Ethernet_wire.sizeof_ethernet)
+    in
+    Netif.write t.netif ?size fill >|= function
     | Ok () -> Ok ()
     | Error e ->
       Log.warn (fun f -> f "netif write errored %a" Netif.pp_error e) ;
       Error e
 
-  let writev t bufs =
-    MProf.Trace.label "ethernet.writev";
-    Netif.writev t.netif bufs >|= function
-    | Ok () -> Ok ()
-    | Error e ->
-      Log.warn (fun f -> f "netif writev errored %a" Netif.pp_error e) ;
-      Error e
-
-  let connect ?(mtu = default_mtu) netif =
+  let connect netif =
     MProf.Trace.label "ethernet.connect";
-    let t = { netif; mtu } in
+    let t = { netif } in
     Log.info (fun f -> f "Connected Ethernet interface %a" Macaddr.pp (mac t));
     Lwt.return t
 

--- a/src/ethernet.mli
+++ b/src/ethernet.mli
@@ -17,7 +17,7 @@
 
 (** OCaml Ethernet (IEEE 802.3) layer *)
 
-module Make ( N:Mirage_net_lwt.S) : sig
+module Make (N : Mirage_net_lwt.S) : sig
   include Mirage_protocols_lwt.ETHIF
 
   val connect : N.t -> t Lwt.t

--- a/src/ethernet.mli
+++ b/src/ethernet.mli
@@ -20,9 +20,7 @@
 module Make ( N:Mirage_net_lwt.S) : sig
   include Mirage_protocols_lwt.ETHIF
 
-  val connect : ?mtu:int -> N.t -> t Lwt.t
-  (** [connect ?mtu netif] connects an ethernet layer on top of the raw
-      network device [netif]. The Maximum Transfer Unit may be set via the
-      optional [?mtu] parameter, otherwise a default value of 1500 will be
-      used. *)
+  val connect : N.t -> t Lwt.t
+  (** [connect netif] connects an ethernet layer on top of the raw
+      network device [netif]. *)
 end

--- a/src/ethernet.mli
+++ b/src/ethernet.mli
@@ -18,7 +18,7 @@
 (** OCaml Ethernet (IEEE 802.3) layer *)
 
 module Make (N : Mirage_net_lwt.S) : sig
-  include Mirage_protocols_lwt.ETHIF
+  include Mirage_protocols_lwt.ETHERNET
 
   val connect : N.t -> t Lwt.t
   (** [connect netif] connects an ethernet layer on top of the raw

--- a/src/ethernet_packet.ml
+++ b/src/ethernet_packet.ml
@@ -1,14 +1,16 @@
+open Mirage_protocols
+
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Ethernet_wire.ethertype;
+  ethertype : Ethif.proto;
 }
 
 type error = string
 
 let pp fmt t =
-  Format.fprintf fmt "%a -> %a: %s" Macaddr.pp t.source
-    Macaddr.pp t.destination (Ethernet_wire.ethertype_to_string t.ethertype)
+  Format.fprintf fmt "%a -> %a: %a" Macaddr.pp t.source
+    Macaddr.pp t.destination Ethif.pp_proto t.ethertype
 
 let equal {source; destination; ethertype} q =
   (Macaddr.compare source q.source) = 0 &&

--- a/src/ethernet_packet.ml
+++ b/src/ethernet_packet.ml
@@ -1,16 +1,14 @@
-open Mirage_protocols
-
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Ethif.proto;
+  ethertype : Mirage_protocols.Ethernet.proto;
 }
 
 type error = string
 
 let pp fmt t =
   Format.fprintf fmt "%a -> %a: %a" Macaddr.pp t.source
-    Macaddr.pp t.destination Ethif.pp_proto t.ethertype
+    Macaddr.pp t.destination Mirage_protocols.Ethernet.pp_proto t.ethertype
 
 let equal {source; destination; ethertype} q =
   (Macaddr.compare source q.source) = 0 &&

--- a/src/ethernet_packet.mli
+++ b/src/ethernet_packet.mli
@@ -1,7 +1,7 @@
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Ethernet_wire.ethertype;
+  ethertype : Mirage_protocols.Ethif.proto;
 }
 
 type error = string

--- a/src/ethernet_packet.mli
+++ b/src/ethernet_packet.mli
@@ -1,7 +1,7 @@
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Mirage_protocols.Ethif.proto;
+  ethertype : Mirage_protocols.Ethernet.proto;
 }
 
 type error = string

--- a/src/ethernet_wire.ml
+++ b/src/ethernet_wire.ml
@@ -6,10 +6,13 @@ type ethernet = {
   } [@@big_endian]
 ]
 
-[%%cenum
-type ethertype =
-  | ARP  [@id 0x0806]
-  | IPv4 [@id 0x0800]
-  | IPv6 [@id 0x86dd]
-  [@@uint16_t]
-]
+let ethertype_to_int = function
+  | `ARP -> 0x0806
+  | `IPv4 -> 0x0800
+  | `IPv6 -> 0x86dd
+
+let int_to_ethertype = function
+  | 0x0806 -> Some `ARP
+  | 0x0800 -> Some `IPv4
+  | 0x86dd -> Some `IPv6
+  | _ -> None


### PR DESCRIPTION
this is on top of #3 and should be merged thereafter, but before a 2.0 release. see https://github.com/mirage/mirage-protocols/pull/16