### PR TITLE
include Mirage_protocols.ETHERNET directly in ethernet

### DIFF
--- a/ethernet.opam
+++ b/ethernet.opam
@@ -23,7 +23,6 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "ppx_cstruct"
   "mirage-net" {>= "3.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
   "mirage-profile" {>= "0.5"}
   "lwt" {>= "3.0.0"}

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,5 @@
 (library
  (name ethernet)
  (public_name ethernet)
- (libraries cstruct macaddr mirage-net mirage-protocols logs lwt mirage-profile)
- (preprocess (pps ppx_cstruct))
- (wrapped false))
+ (libraries cstruct macaddr mirage-net logs lwt mirage-profile)
+ (preprocess (pps ppx_cstruct)))

--- a/src/ethernet.mli
+++ b/src/ethernet.mli
@@ -17,8 +17,87 @@
 
 (** OCaml Ethernet (IEEE 802.3) layer *)
 
+(** Ethernet (IEEE 802.3) is a widely used data link layer. The hardware is
+   usually a twisted pair or fibre connection, on the software side it consists
+   of an Ethernet header where source and destination mac addresses, and a type
+   field, indicating the type of the next layer, are present. The Ethernet layer
+   consists of network card mac address and MTU information, and provides
+   decapsulation and encapsulation. *)
+
+(** {2 Ethernet layer} *)
+
+module Packet : sig
+  (** Ethernet protocols. *)
+  type proto = [ `ARP | `IPv4 | `IPv6 ]
+
+  (** [pp_proto ppf proto] pretty-prints the ethernet protocol [proto] on [ppf]. *)
+  val pp_proto: proto Fmt.t
+
+  (** The type of an Ethernet packet. *)
+  type t = {
+    source : Macaddr.t;
+    destination : Macaddr.t;
+    ethertype : proto;
+  }
+
+  (** [sizeof_ethernet] is the byte size of the ethernet header. *)
+  val sizeof_ethernet : int
+
+  (** [of_cstruct buffer] attempts to decode the buffer as ethernet packet. It
+      may result an error if the buffer is too small, or the protocol is not
+      supported. *)
+  val of_cstruct : Cstruct.t -> (t * Cstruct.t, string) result
+
+  (** [into_cstruct t cs] attempts to encode the ethernet packet [t] into the
+      buffer [cs] (at offset 0). This may fail if the buffer is not big
+      enough. *)
+  val into_cstruct : t -> Cstruct.t -> (unit, string) result
+
+  (** [make_cstruct t] encodes the ethernet packet [t] into a freshly allocated
+      buffer. *)
+  val make_cstruct : t -> Cstruct.t
+end
+
+module type S = sig
+
+  type nonrec error = private [> `Exceeds_mtu ]
+  (** The type for ethernet interface errors. *)
+
+  val pp_error: error Fmt.t
+  (** [pp_error] is the pretty-printer for errors. *)
+
+  type t
+  (** The type representing the internal state of the ethernet layer. *)
+
+  val disconnect: t -> unit Lwt.t
+  (** Disconnect from the ethernet layer. While this might take some time to
+      complete, it can never result in an error. *)
+
+  val write: t -> ?src:Macaddr.t -> Macaddr.t -> Packet.proto -> ?size:int ->
+    (Cstruct.t -> int) -> (unit, error) result Lwt.t
+  (** [write eth ~src dst proto ~size payload] outputs an ethernet frame which
+     header is filled by [eth], and its payload is the buffer from the call to
+     [payload]. [Payload] gets a buffer of [size] (defaults to mtu) to fill with
+     their payload. If [size] exceeds {!mtu}, an error is returned. *)
+
+  val mac: t -> Macaddr.t
+  (** [mac eth] is the MAC address of [eth]. *)
+
+  val mtu: t -> int
+  (** [mtu eth] is the Maximum Transmission Unit of the [eth] i.e. the maximum
+      size of the payload, excluding the ethernet frame header. *)
+
+  val input:
+    arpv4:(Cstruct.t -> unit Lwt.t) ->
+    ipv4:(Cstruct.t -> unit Lwt.t) ->
+    ipv6:(Cstruct.t -> unit Lwt.t) ->
+    t -> Cstruct.t -> unit Lwt.t
+  (** [input ~arpv4 ~ipv4 ~ipv6 eth buffer] decodes the buffer and demultiplexes
+      it depending on the protocol to the callback. *)
+end
+
 module Make (N : Mirage_net.S) : sig
-  include Mirage_protocols.ETHERNET
+  include S
 
   val connect : N.t -> t Lwt.t
   (** [connect netif] connects an ethernet layer on top of the raw

--- a/src/ethernet_packet.ml
+++ b/src/ethernet_packet.ml
@@ -1,14 +1,21 @@
+type proto = [ `ARP | `IPv4 | `IPv6 ]
+
+let pp_proto ppf = function
+  | `ARP -> Fmt.string ppf "ARP"
+  | `IPv4 -> Fmt.string ppf "IPv4"
+  | `IPv6 -> Fmt.string ppf "IPv6"
+
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Mirage_protocols.Ethernet.proto;
+  ethertype : proto;
 }
 
 type error = string
 
 let pp fmt t =
   Format.fprintf fmt "%a -> %a: %a" Macaddr.pp t.source
-    Macaddr.pp t.destination Mirage_protocols.Ethernet.pp_proto t.ethertype
+    Macaddr.pp t.destination pp_proto t.ethertype
 
 let equal {source; destination; ethertype} q =
   (Macaddr.compare source q.source) = 0 &&

--- a/src/ethernet_packet.mli
+++ b/src/ethernet_packet.mli
@@ -1,7 +1,10 @@
+type proto = [ `ARP | `IPv4 | `IPv6 ]
+val pp_proto: proto Fmt.t
+
 type t = {
   source : Macaddr.t;
   destination : Macaddr.t;
-  ethertype : Mirage_protocols.Ethernet.proto;
+  ethertype : proto;
 }
 
 type error = string
@@ -12,6 +15,7 @@ val equal : t -> t -> bool
 module Unmarshal : sig
   val of_cstruct : Cstruct.t -> ((t * Cstruct.t), error) result
 end
+
 module Marshal : sig
   (** [into_cstruct t buf] writes a 14-byte ethernet header representing
       [t.ethertype], [t.src_mac], and [t.dst_mac] to [buf] at offset 0.


### PR DESCRIPTION
This moves us to have the interface and implementation side-by-side, allowing
easier changes. It also removes the mirage-protocols dependency.

The motivation is to reduce our opam package complexity (cone) -- as discussed on our meeting last week. Some of this is neatly possible already with the existing setup -- esp. mirage-protocols and mirage-stack can just disappear (this needs some reverse dependency fixes, since all the unikernels use Mirage_stack.V4V6). For ethernet -- only used by arp, tcpip, charrua -- this is pretty straightforward.

If you feel that the git history of mirage-protocols is relevant, please raise your voice. //cc @mirage/core